### PR TITLE
Deploy commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - linux
   - osx
 go:
-  - 1.6.3
   - 1.7.3
   - tip
 env:

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ prepare-test-server:
 	TSURU_TARGET="$${TSURU_TEST_HOST}" TSURU_TOKEN="$${TSURU_TEST_TOKEN}" tsuru-admin plan-create -c 512 huge || true
 	TSURU_TARGET="$${TSURU_TEST_HOST}" TSURU_TOKEN="$${TSURU_TEST_TOKEN}" tsuru team-create myteam || true
 	TSURU_TARGET="$${TSURU_TEST_HOST}" TSURU_TOKEN="$${TSURU_TEST_TOKEN}" tsuru team-create superteam || true
-	TSURU_TARGET="$${TSURU_TEST_HOST}" TSURU_TOKEN="$${TSURU_TEST_TOKEN}" tsuru-admin user-quota-change $$(tsuru user-info | grep Email: | awk '{print $$2}') -- -1
+	TSURU_TARGET="$${TSURU_TEST_HOST}" TSURU_TOKEN="$${TSURU_TEST_TOKEN}" tsuru-admin user-quota-change $$(tsuru user-info | grep Email: | awk '{print $$2}') unlimited

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ commands below should get tranor up and running:
 % tranor target-set <remote-tranor-config-server>
 ```
 
-The config server is an HTTP endpoint that contains the Tsuru target server and
-the list of environment names and DNS suffixes, in the following format:
+The config server is an HTTP endpoint that contains the Tsuru target server,
+the Docker registry used by the tsuru setup and the list of environment names
+and DNS suffixes, in the following format:
 
 
 ```json
 {
 	"target": "http://tsuru.example.com",
+	"registry": "docker-registry.example.com",
 	"envs": [
 		{
 			"name": "dev",

--- a/app.go
+++ b/app.go
@@ -35,7 +35,7 @@ func createApp(client *cmd.Client, opts createAppOptions) (map[string]string, er
 		return nil, err
 	}
 	payload, _ := form.EncodeToString(opts)
-	req, err := http.NewRequest("POST", url, strings.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func updateApp(client *cmd.Client, opts createAppOptions) error {
 	opts.Name = ""
 	opts.Platform = ""
 	payload, _ := form.EncodeToString(opts)
-	req, err := http.NewRequest("PUT", url, strings.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func deleteApps(apps []app, client *cmd.Client, w io.Writer) ([]error, error) {
 		if err != nil {
 			return nil, err
 		}
-		req, err := http.NewRequest("DELETE", url, nil)
+		req, err := http.NewRequest(http.MethodDelete, url, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -100,7 +100,7 @@ func listApps(client *cmd.Client, filters map[string]string) ([]app, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func setEnvVars(client *cmd.Client, appName string, envVars *api.Envs) error {
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("POST", url, strings.NewReader(v.Encode()))
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(v.Encode()))
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func unsetEnvVars(client *cmd.Client, appName string, noRestart bool, envVars []
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("DELETE", url, nil)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func doReq(client *cmd.Client, path string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -24,7 +24,7 @@ func TestCreateApp(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps",
 		code:    http.StatusOK,
 		payload: []byte(`{"repository_url":"git@example.com:app.git"}`),
@@ -53,7 +53,7 @@ func TestCreateApp(t *testing.T) {
 		t.Errorf("wrong app map returned\nwant %#v\ngot  %#v", expectedApp, app)
 	}
 	req := fakeServer.reqs[0]
-	if req.Method != "POST" {
+	if req.Method != http.MethodPost {
 		t.Errorf("wrong method. Want POST. Got %s", req.Method)
 	}
 	if req.URL.Path != "/1.0/apps" {
@@ -96,7 +96,7 @@ func TestUpdateApp(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "PUT",
+		method:  http.MethodPut,
 		path:    "/apps/myapp",
 		code:    http.StatusOK,
 		payload: []byte(`{"repository_url":"git@example.com:app.git"}`),
@@ -141,7 +141,7 @@ func TestUpdateAppNotFound(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "PUT",
+		method:  http.MethodPut,
 		path:    "/apps/myapp",
 		code:    http.StatusNotFound,
 		payload: []byte("app not found"),
@@ -184,12 +184,12 @@ func TestDeleteApps(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method: "DELETE",
+		method: http.MethodDelete,
 		path:   "/apps/proj1-dev",
 		code:   http.StatusOK,
 	})
 	fakeServer.prepareResponse(preparedResponse{
-		method: "DELETE",
+		method: http.MethodDelete,
 		path:   "/apps/proj1-prod",
 		code:   http.StatusOK,
 	})
@@ -215,7 +215,7 @@ func TestDeleteApps(t *testing.T) {
 	}
 	paths := []string{"/1.0/apps/proj1-dev", "/1.0/apps/proj1-qa", "/1.0/apps/proj1-prod"}
 	for i, req := range fakeServer.reqs {
-		if req.Method != "DELETE" {
+		if req.Method != http.MethodDelete {
 			t.Errorf("wrong method. Want DELETE. Got %s", req.Method)
 		}
 		if req.URL.Path != paths[i] {
@@ -251,13 +251,13 @@ func TestListApps(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?",
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
 	})
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps",
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
@@ -298,12 +298,12 @@ func TestListAppsEmpty(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method: "GET",
+		method: http.MethodGet,
 		path:   "/apps?",
 		code:   http.StatusNoContent,
 	})
 	fakeServer.prepareResponse(preparedResponse{
-		method: "GET",
+		method: http.MethodGet,
 		path:   "/apps",
 		code:   http.StatusNoContent,
 	})
@@ -344,7 +344,7 @@ func TestLastDeploy(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/deploys?limit=1&app=myapp",
 		code:    http.StatusOK,
 		payload: []byte(deployments),
@@ -376,7 +376,7 @@ func TestLastDeployEmpty(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method: "GET",
+		method: http.MethodGet,
 		path:   "/deploys?limit=1&app=myapp",
 		code:   http.StatusNoContent,
 	})
@@ -414,7 +414,7 @@ func TestGetApp(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps/proj3-prod",
 		code:    http.StatusOK,
 		payload: []byte(appInfo2),
@@ -445,7 +445,7 @@ func TestGetAppNotFound(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method: "GET",
+		method: http.MethodGet,
 		path:   "/apps/proj1-prod",
 		code:   http.StatusNotFound,
 	})
@@ -484,7 +484,7 @@ func TestSetEnvVars(t *testing.T) {
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
 		code:    http.StatusOK,
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps/proj1-prod/env",
 		payload: []byte("{}"),
 	})
@@ -566,7 +566,7 @@ func TestGetEnvVars(t *testing.T) {
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
 		code:    http.StatusOK,
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps/proj1-prod/env",
 		payload: []byte(`[{"name":"USER_NAME","value":"root","public":true},{"name":"USER_PASSWORD","value":"r00t","public":false}]`),
 	})
@@ -643,7 +643,7 @@ func TestUnsetEnvVars(t *testing.T) {
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
 		code:     http.StatusOK,
-		method:   "DELETE",
+		method:   http.MethodDelete,
 		path:     "/apps/proj1-prod/env",
 		payload:  []byte("{}"),
 		ignoreQS: true,

--- a/deploy.go
+++ b/deploy.go
@@ -1,0 +1,5 @@
+// Copyright 2016 EF CTX. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main

--- a/deploy.go
+++ b/deploy.go
@@ -76,7 +76,7 @@ func (c *projectDeploy) Run(ctx *cmd.Context, cli *cmd.Client) error {
 	}
 
 	if checkEnv && apps[0].Env.Name != c.envName {
-		return fmt.Errorf("can only deploy directly to %q, use promote to deploy to other environments", apps[0].Env.Name)
+		return fmt.Errorf("can only deploy directly to %q, use -p/--promote to deploy to other environments", apps[0].Env.Name)
 	}
 	tsuruDeployCommand.Flags().Parse(true, flags)
 	return tsuruDeployCommand.Run(ctx, cli)

--- a/deploy.go
+++ b/deploy.go
@@ -3,3 +3,116 @@
 // license that can be found in the LICENSE file.
 
 package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/tsuru/gnuflag"
+	"github.com/tsuru/tsuru-client/tsuru/client"
+	"github.com/tsuru/tsuru/cmd"
+)
+
+var (
+	tsuruDeployCommand     cmd.FlaggedCommand = &client.AppDeploy{}
+	tsuruDeployListCommand cmd.FlaggedCommand = &client.AppDeployList{}
+)
+
+type projectDeploy struct {
+	fs          *gnuflag.FlagSet
+	projectName string
+	envName     string
+	version     string
+	image       string
+}
+
+func (c *projectDeploy) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:  "project-deploy",
+		Usage: "tranor project-deploy -n/--project-name <projectname> -e/--env <environment> [-i/--image dockerimage] [-v/version vNN] [content]",
+		Desc: `deploys a new version of a project. Also used to promote a version from one environment to another
+
+Can deploy the project using one of the following strategies:
+
+ - Content upload: just provide the list of files/directories to deploy as argument
+ - Docker image: use the flags -i/--image
+ - Version (also used for rollback): use the flags -v/--version
+`,
+	}
+}
+
+func (c *projectDeploy) Run(ctx *cmd.Context, cli *cmd.Client) error {
+	ctx.RawOutput()
+	if c.projectName == "" || c.envName == "" {
+		return errors.New("please provide the project name and the environment")
+	}
+	appName := fmt.Sprintf("%s-%s", c.projectName, c.envName)
+	flags := []string{"-a", appName}
+	if len(ctx.Args) > 0 {
+		if c.image != "" || c.version != "" {
+			return errors.New("please specify only one of the image, version or the list of files/directories to upload")
+		}
+	} else if c.image != "" {
+		if c.version != "" {
+			return errors.New("please specify only one of the image, version or the list of files/directories to upload")
+		}
+		flags = append(flags, "-i", c.image)
+	} else if c.version != "" {
+		// TODO(fss): implement version-based deployment.
+	} else {
+		return errors.New("please specify either the image, version or the list of files/directories to upload")
+	}
+	err := tsuruDeployCommand.Flags().Parse(true, flags)
+	if err != nil {
+		return err
+	}
+	return tsuruDeployCommand.Run(ctx, cli)
+}
+
+func (c *projectDeploy) Flags() *gnuflag.FlagSet {
+	if c.fs == nil {
+		c.fs = gnuflag.NewFlagSet("project-deploy", gnuflag.ExitOnError)
+		c.fs.StringVar(&c.projectName, "project-name", "", "name of the project to deploy to")
+		c.fs.StringVar(&c.projectName, "n", "", "name of the project to deploy to")
+		c.fs.StringVar(&c.envName, "env", "", "environment to deploy to")
+		c.fs.StringVar(&c.envName, "e", "", "environment to deploy to")
+		c.fs.StringVar(&c.version, "version", "", "version to deploy (when promoting from one environment to another")
+		c.fs.StringVar(&c.version, "v", "", "version to deploy (when promoting from one environment to another")
+		c.fs.StringVar(&c.image, "image", "", "Docker image to deploy")
+		c.fs.StringVar(&c.image, "i", "", "Docker image to deploy")
+	}
+	return c.fs
+}
+
+type projectDeployList struct {
+	fs          *gnuflag.FlagSet
+	projectName string
+	envName     string
+}
+
+func (c *projectDeployList) Info() *cmd.Info {
+	return &cmd.Info{
+		Name: "project-deploy-list",
+		Desc: "lists all deployments of the project in the given environment",
+	}
+}
+
+func (c *projectDeployList) Run(ctx *cmd.Context, cli *cmd.Client) error {
+	if c.projectName == "" || c.envName == "" {
+		return errors.New("please provide the project name and the environment")
+	}
+	appName := fmt.Sprintf("%s-%s", c.projectName, c.envName)
+	tsuruDeployListCommand.Flags().Parse(true, []string{"-a", appName})
+	return tsuruDeployListCommand.Run(ctx, cli)
+}
+
+func (c *projectDeployList) Flags() *gnuflag.FlagSet {
+	if c.fs == nil {
+		c.fs = gnuflag.NewFlagSet("project-deploy", gnuflag.ExitOnError)
+		c.fs.StringVar(&c.projectName, "project-name", "", "name of the project to deploy to")
+		c.fs.StringVar(&c.projectName, "n", "", "name of the project to deploy to")
+		c.fs.StringVar(&c.envName, "env", "", "environment to deploy to")
+		c.fs.StringVar(&c.envName, "e", "", "environment to deploy to")
+	}
+	return c.fs
+}

--- a/deploy.go
+++ b/deploy.go
@@ -22,21 +22,21 @@ type projectDeploy struct {
 	fs          *gnuflag.FlagSet
 	projectName string
 	envName     string
-	version     string
+	promoteFrom string
 	image       string
 }
 
 func (c *projectDeploy) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:  "project-deploy",
-		Usage: "tranor project-deploy -n/--project-name <projectname> -e/--env <environment> [-i/--image dockerimage] [-v/version vNN] [content]",
+		Usage: "tranor project-deploy -n/--project-name <projectname> -e/--env <environment> [-i/--image dockerimage] [-p/--promote parent-env] [content]",
 		Desc: `deploys a new version of a project. Also used to promote a version from one environment to another
 
 Can deploy the project using one of the following strategies:
 
  - Content upload: just provide the list of files/directories to deploy as argument
  - Docker image: use the flags -i/--image
- - Version (also used for rollback): use the flags -v/--version
+ - Promoting from other environment: use the flags -p/--promote
 `,
 	}
 }
@@ -46,27 +46,53 @@ func (c *projectDeploy) Run(ctx *cmd.Context, cli *cmd.Client) error {
 	if c.projectName == "" || c.envName == "" {
 		return errors.New("please provide the project name and the environment")
 	}
-	appName := fmt.Sprintf("%s-%s", c.projectName, c.envName)
-	flags := []string{"-a", appName}
-	if len(ctx.Args) > 0 {
-		if c.image != "" || c.version != "" {
-			return errors.New("please specify only one of the image, version or the list of files/directories to upload")
-		}
-	} else if c.image != "" {
-		if c.version != "" {
-			return errors.New("please specify only one of the image, version or the list of files/directories to upload")
-		}
-		flags = append(flags, "-i", c.image)
-	} else if c.version != "" {
-		// TODO(fss): implement version-based deployment.
-	} else {
-		return errors.New("please specify either the image, version or the list of files/directories to upload")
-	}
-	err := tsuruDeployCommand.Flags().Parse(true, flags)
+	// fail soon if project doesn't exist
+	apps, err := projectApps(cli, c.projectName)
 	if err != nil {
 		return err
 	}
+
+	appName := fmt.Sprintf("%s-%s", c.projectName, c.envName)
+	flags := []string{"-a", appName}
+	checkEnv := true
+	if len(ctx.Args) > 0 {
+		if c.image != "" || c.promoteFrom != "" {
+			return errors.New("please specify only one of the image, parent env or the list of files/directories to upload")
+		}
+	} else if c.image != "" {
+		if c.promoteFrom != "" {
+			return errors.New("please specify only one of the image, parent env or the list of files/directories to upload")
+		}
+		flags = append(flags, "-i", c.image)
+	} else if c.promoteFrom != "" {
+		promoteFlags, err := c.promoteFlags(c.projectName, c.promoteFrom, cli)
+		if err != nil {
+			return err
+		}
+		flags = append(flags, promoteFlags...)
+		checkEnv = false
+	} else {
+		return errors.New("please specify either the image, parent env or the list of files/directories to upload")
+	}
+
+	if checkEnv && apps[0].Env.Name != c.envName {
+		return fmt.Errorf("can only deploy directly to %q, use promote to deploy to other environments", apps[0].Env.Name)
+	}
+	tsuruDeployCommand.Flags().Parse(true, flags)
 	return tsuruDeployCommand.Run(ctx, cli)
+}
+
+func (c *projectDeploy) promoteFlags(projectName, fromEnv string, cli *cmd.Client) ([]string, error) {
+	config, _ := loadConfigFile()
+	originApp := fmt.Sprintf("%s-%s", projectName, fromEnv)
+	d, err := lastDeploy(cli, originApp)
+	if err != nil {
+		return nil, err
+	}
+	if d.Image == "" {
+		return nil, fmt.Errorf("no version running in %q", fromEnv)
+	}
+	return []string{"-i", config.imageApp(originApp, d.Image)}, nil
 }
 
 func (c *projectDeploy) Flags() *gnuflag.FlagSet {
@@ -76,8 +102,8 @@ func (c *projectDeploy) Flags() *gnuflag.FlagSet {
 		c.fs.StringVar(&c.projectName, "n", "", "name of the project to deploy to")
 		c.fs.StringVar(&c.envName, "env", "", "environment to deploy to")
 		c.fs.StringVar(&c.envName, "e", "", "environment to deploy to")
-		c.fs.StringVar(&c.version, "version", "", "version to deploy (when promoting from one environment to another")
-		c.fs.StringVar(&c.version, "v", "", "version to deploy (when promoting from one environment to another")
+		c.fs.StringVar(&c.promoteFrom, "promote", "", "promote version from the given environment")
+		c.fs.StringVar(&c.promoteFrom, "p", "", "promote version from the given environment")
 		c.fs.StringVar(&c.image, "image", "", "Docker image to deploy")
 		c.fs.StringVar(&c.image, "i", "", "Docker image to deploy")
 	}

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -1,0 +1,211 @@
+// Copyright 2016 EF CTX. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tsuru/gnuflag"
+	"github.com/tsuru/tsuru-client/tsuru/client"
+	"github.com/tsuru/tsuru/cmd"
+)
+
+func TestProjectDeployFlags(t *testing.T) {
+	oldCommand := tsuruDeployCommand
+	defer func() { tsuruDeployCommand = oldCommand }()
+	var tests = []struct {
+		testCase      string
+		flags         []string
+		args          []string
+		expectedFlags map[string]string
+		expectedArgs  []string
+	}{
+		{
+			"upload-based deploy",
+			[]string{"-n", "myproj", "-e", "dev"},
+			[]string{"."},
+			map[string]string{
+				"app": "myproj-dev",
+				"a":   "myproj-dev",
+			},
+			[]string{"."},
+		},
+		{
+			"image-based deploy",
+			[]string{"-n", "myproj", "-e", "dev", "-i", "some/image"},
+			nil,
+			map[string]string{
+				"a":     "myproj-dev",
+				"app":   "myproj-dev",
+				"i":     "some/image",
+				"image": "some/image",
+			},
+			nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testCase, func(t *testing.T) {
+			fakeCommand := fakeTsuruCommand{FlaggedCommand: &client.AppDeploy{}}
+			tsuruDeployCommand = &fakeCommand
+			var c projectDeploy
+			ctx := cmd.Context{Args: test.args}
+			c.Flags().Parse(true, test.flags)
+			err := c.Run(&ctx, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotFlags := fakeCommand.inputFlags(); !reflect.DeepEqual(gotFlags, test.expectedFlags) {
+				t.Errorf("wrong flags sent to app-deploy\ngot  %#v\nwant %#v", gotFlags, test.expectedFlags)
+			}
+		})
+	}
+}
+
+func TestProjectDeployErrors(t *testing.T) {
+	var tests = []struct {
+		testCase string
+		flags    []string
+		args     []string
+		errMsg   string
+	}{
+		{
+			"missing project name",
+			nil,
+			nil,
+			"please provide the project name and the environment",
+		},
+		{
+			"missing env name",
+			[]string{"-n", "myproj"},
+			nil,
+			"please provide the project name and the environment",
+		},
+		{
+			"missing deploy options",
+			[]string{"-n", "myproj", "-e", "dev"},
+			nil,
+			"please specify either the image, version or the list of files/directories to upload",
+		},
+		{
+			"specifying all options",
+			[]string{"-n", "myproj", "-e", "dev", "-i", "someimage", "-v", "someversion"},
+			[]string{"."},
+			"please specify only one of the image, version or the list of files/directories to upload",
+		},
+		{
+			"specifying image and version",
+			[]string{"-n", "myproj", "-e", "dev", "-i", "someimage", "-v", "someversion"},
+			nil,
+			"please specify only one of the image, version or the list of files/directories to upload",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testCase, func(t *testing.T) {
+			var c projectDeploy
+			ctx := cmd.Context{Args: test.args}
+			c.Flags().Parse(true, test.flags)
+			err := c.Run(&ctx, nil)
+			if err == nil {
+				t.Fatal("unexpected <nil> error")
+			}
+			if err.Error() != test.errMsg {
+				t.Errorf("wrong error message\ngot  %q\nwant %q", err.Error(), test.errMsg)
+			}
+		})
+	}
+}
+
+func TestProjectDeployListFlags(t *testing.T) {
+	oldCommand := tsuruDeployListCommand
+	defer func() { tsuruDeployListCommand = oldCommand }()
+	fakeCommand := fakeTsuruCommand{FlaggedCommand: &client.AppDeployList{}}
+	tsuruDeployListCommand = &fakeCommand
+	var c projectDeployList
+	ctx := cmd.Context{}
+	c.Flags().Parse(true, []string{"-n", "myproj", "-e", "dev"})
+	err := c.Run(&ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedFlags := map[string]string{
+		"a":   "myproj-dev",
+		"app": "myproj-dev",
+	}
+	if gotFlags := fakeCommand.inputFlags(); !reflect.DeepEqual(gotFlags, expectedFlags) {
+		t.Errorf("wrong flags sent to app-deploy\ngot  %#v\nwant %#v", gotFlags, expectedFlags)
+	}
+}
+
+func TestProjectDeployListMissingParams(t *testing.T) {
+	var tests = []struct {
+		testCase string
+		flags    []string
+		args     []string
+		errMsg   string
+	}{
+		{
+			"missing project name",
+			nil,
+			nil,
+			"please provide the project name and the environment",
+		},
+		{
+			"missing env name",
+			[]string{"-n", "myproj"},
+			nil,
+			"please provide the project name and the environment",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testCase, func(t *testing.T) {
+			var c projectDeployList
+			ctx := cmd.Context{Args: test.args}
+			c.Flags().Parse(true, test.flags)
+			err := c.Run(&ctx, nil)
+			if err == nil {
+				t.Fatal("unexpected <nil> error")
+			}
+			if err.Error() != test.errMsg {
+				t.Errorf("wrong error message\ngot  %q\nwant %q", err.Error(), test.errMsg)
+			}
+		})
+	}
+}
+
+type fakeTsuruCommand struct {
+	flags  map[string]gnuflag.Value
+	ctx    *cmd.Context
+	client *cmd.Client
+	cmd.FlaggedCommand
+	called bool
+}
+
+func (c *fakeTsuruCommand) Run(ctx *cmd.Context, cli *cmd.Client) error {
+	c.client = cli
+	c.ctx = ctx
+	c.called = true
+	return nil
+}
+
+func (c *fakeTsuruCommand) Flags() *gnuflag.FlagSet {
+	c.flags = make(map[string]gnuflag.Value)
+	fs := gnuflag.NewFlagSet("app-deploy", gnuflag.ExitOnError)
+	c.FlaggedCommand.Flags().VisitAll(func(f *gnuflag.Flag) {
+		fs.Var(f.Value, f.Name, f.Usage)
+		c.flags[f.Name] = f.Value
+	})
+	return fs
+}
+
+func (c *fakeTsuruCommand) inputFlags() map[string]string {
+	r := make(map[string]string, len(c.flags))
+	for n, v := range c.flags {
+		if value := v.String(); value != "" {
+			r[n] = v.String()
+		}
+	}
+	return r
+}

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -19,7 +19,7 @@ func TestProjectDeployPromoteFlags(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?name=" + url.QueryEscape("^proj1"),
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
@@ -27,20 +27,20 @@ func TestProjectDeployPromoteFlags(t *testing.T) {
 	envNames := []string{"dev", "qa", "stage", "prod"}
 	for _, envName := range envNames {
 		fakeServer.prepareResponse(preparedResponse{
-			method:  "GET",
+			method:  http.MethodGet,
 			path:    "/apps/proj1-" + envName,
 			code:    http.StatusOK,
 			payload: []byte(appInfo1),
 		})
 	}
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps/proj1-dev",
 		code:    http.StatusOK,
 		payload: []byte(appInfo1),
 	})
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/deploys?limit=1&app=proj1-dev",
 		code:    http.StatusOK,
 		payload: []byte(deployments),
@@ -80,7 +80,7 @@ func TestProjectDeployPromoteFailToGetLastDeploy(t *testing.T) {
 	fakeServer := newFakeServer(t)
 	defer fakeServer.stop()
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?name=" + url.QueryEscape("^proj1"),
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
@@ -88,20 +88,20 @@ func TestProjectDeployPromoteFailToGetLastDeploy(t *testing.T) {
 	envNames := []string{"dev", "qa", "stage", "prod"}
 	for _, envName := range envNames {
 		fakeServer.prepareResponse(preparedResponse{
-			method:  "GET",
+			method:  http.MethodGet,
 			path:    "/apps/proj1-" + envName,
 			code:    http.StatusOK,
 			payload: []byte(appInfo1),
 		})
 	}
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps/proj1-dev",
 		code:    http.StatusOK,
 		payload: []byte(appInfo1),
 	})
 	fakeServer.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/deploys?limit=1&app=proj1-dev",
 		code:    http.StatusInternalServerError,
 		payload: []byte("something went wrong"),

--- a/deployi_test.go
+++ b/deployi_test.go
@@ -118,7 +118,7 @@ func TestProjectDeployErrors(t *testing.T) {
 			"invalid direct deploy",
 			[]string{"-n", "myproj", "-e", "stage"},
 			[]string{"target/debug"},
-			`can only deploy directly to "dev", use promote to deploy to other environments`,
+			`can only deploy directly to "dev", use -p/--promote to deploy to other environments`,
 		},
 		{
 			"promote from environment that hasn't been deployed",

--- a/deployi_test.go
+++ b/deployi_test.go
@@ -1,0 +1,172 @@
+// Copyright 2016 EF CTX. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/tsuru/tsuru-client/tsuru/client"
+	"github.com/tsuru/tsuru/cmd"
+)
+
+func TestProjectDeployFlags(t *testing.T) {
+	cleanup := createTestProject("myproj", t)
+	oldCommand := tsuruDeployCommand
+	defer func() {
+		tsuruDeployCommand = oldCommand
+		cleanup()
+	}()
+	var tests = []struct {
+		testCase      string
+		flags         []string
+		args          []string
+		expectedFlags map[string]string
+		expectedArgs  []string
+	}{
+		{
+			"upload-based deploy",
+			[]string{"-n", "myproj", "-e", "dev"},
+			[]string{"."},
+			map[string]string{
+				"app": "myproj-dev",
+				"a":   "myproj-dev",
+			},
+			[]string{"."},
+		},
+		{
+			"image-based deploy",
+			[]string{"-n", "myproj", "-e", "dev", "-i", "some/image"},
+			nil,
+			map[string]string{
+				"a":     "myproj-dev",
+				"app":   "myproj-dev",
+				"i":     "some/image",
+				"image": "some/image",
+			},
+			nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testCase, func(t *testing.T) {
+			fakeCommand := fakeTsuruCommand{FlaggedCommand: &client.AppDeploy{}}
+			tsuruDeployCommand = &fakeCommand
+			var c projectDeploy
+			ctx := cmd.Context{Args: test.args}
+			client := cmd.NewClient(http.DefaultClient, &ctx, &cmd.Manager{})
+			c.Flags().Parse(true, test.flags)
+			err := c.Run(&ctx, client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotFlags := fakeCommand.inputFlags(); !reflect.DeepEqual(gotFlags, test.expectedFlags) {
+				t.Errorf("wrong flags sent to app-deploy\ngot  %#v\nwant %#v", gotFlags, test.expectedFlags)
+			}
+		})
+	}
+}
+
+func TestProjectDeployErrors(t *testing.T) {
+	cleanup := createTestProject("myproj", t)
+	defer cleanup()
+	var tests = []struct {
+		testCase string
+		flags    []string
+		args     []string
+		errMsg   string
+	}{
+		{
+			"missing project name",
+			nil,
+			nil,
+			"please provide the project name and the environment",
+		},
+		{
+			"missing env name",
+			[]string{"-n", "myproj"},
+			nil,
+			"please provide the project name and the environment",
+		},
+		{
+			"project not found",
+			[]string{"-n", "someproj", "-e", "dev"},
+			nil,
+			"project not found",
+		},
+		{
+			"missing deploy options",
+			[]string{"-n", "myproj", "-e", "dev"},
+			nil,
+			"please specify either the image, parent env or the list of files/directories to upload",
+		},
+		{
+			"specifying all options",
+			[]string{"-n", "myproj", "-e", "stage", "-i", "someimage", "-p", "env"},
+			[]string{"."},
+			"please specify only one of the image, parent env or the list of files/directories to upload",
+		},
+		{
+			"specifying image and version",
+			[]string{"-n", "myproj", "-e", "stage", "-i", "someimage", "-p", "env"},
+			nil,
+			"please specify only one of the image, parent env or the list of files/directories to upload",
+		},
+		{
+			"invalid direct deploy",
+			[]string{"-n", "myproj", "-e", "stage"},
+			[]string{"target/debug"},
+			`can only deploy directly to "dev", use promote to deploy to other environments`,
+		},
+		{
+			"promote from environment that hasn't been deployed",
+			[]string{"-n", "myproj", "-e", "stage", "-p", "dev"},
+			nil,
+			`no version running in "dev"`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testCase, func(t *testing.T) {
+			var c projectDeploy
+			ctx := cmd.Context{Args: test.args}
+			client := cmd.NewClient(http.DefaultClient, &ctx, &cmd.Manager{})
+			c.Flags().Parse(true, test.flags)
+			err := c.Run(&ctx, client)
+			if err == nil {
+				t.Fatal("unexpected <nil> error")
+			}
+			if err.Error() != test.errMsg {
+				t.Errorf("wrong error message\ngot  %q\nwant %q", err.Error(), test.errMsg)
+			}
+		})
+	}
+}
+
+func createTestProject(name string, t *testing.T) func() {
+	tsuruServer.reset()
+	cleanup, err := setupFakeConfig(tsuruServer.url(), tsuruServer.token())
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := loadConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := cmd.NewClient(http.DefaultClient, &cmd.Context{}, &cmd.Manager{})
+	apps, err := createApps(config.Environments, client, name, createAppOptions{
+		Plan:        "medium",
+		Description: "some project",
+		Team:        "myteam",
+		Platform:    "python",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = setCNames(apps, client, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cleanup
+}

--- a/env.go
+++ b/env.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/tsuru/tsuru/cmd"
 )
@@ -43,6 +44,7 @@ func (envList) Run(ctx *cmd.Context, _ *cmd.Client) error {
 // Config represents the configuration for the tranor command line.
 type Config struct {
 	Target       string        `json:"target"`
+	Registry     string        `json:"registry"`
 	Environments []Environment `json:"envs"`
 }
 
@@ -52,6 +54,14 @@ func (c *Config) envNames() []string {
 		names[i] = env.Name
 	}
 	return names
+}
+
+func (c *Config) imageApp(appName, version string) string {
+	parts := []string{"tsuru", "app-" + appName + ":" + version}
+	if c.Registry != "" {
+		parts = []string{c.Registry, parts[0], parts[1]}
+	}
+	return strings.Join(parts, "/")
 }
 
 func (c *Config) writeTarget() error {

--- a/env_test.go
+++ b/env_test.go
@@ -91,7 +91,8 @@ func TestLoadConfigFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedConfig := Config{
-		Target: "http://tsuru-api.example.com",
+		Target:   "http://tsuru-api.example.com",
+		Registry: "localhost:5000",
 		Environments: []Environment{
 			{Name: "dev", DNSSuffix: "dev.example.com"},
 			{Name: "qa", DNSSuffix: "qa.example.com"},
@@ -231,6 +232,33 @@ func TestConfigEnvNames(t *testing.T) {
 	gotNames := c.envNames()
 	if !reflect.DeepEqual(gotNames, expectedNames) {
 		t.Errorf("wrong env names returned\nwant %#v\ngot  %#v", expectedNames, gotNames)
+	}
+}
+
+func TestConfigImageApp(t *testing.T) {
+	var tests = []struct {
+		testCase      string
+		config        Config
+		expectedImage string
+	}{
+		{
+			"with registry",
+			Config{Registry: "localhost:4040"},
+			"localhost:4040/tsuru/app-myapp:v10",
+		},
+		{
+			"without registry",
+			Config{},
+			"tsuru/app-myapp:v10",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testCase, func(t *testing.T) {
+			gotImage := test.config.imageApp("myapp", "v10")
+			if gotImage != test.expectedImage {
+				t.Errorf("wrong image returned\nwant %q\ngot  %q", test.expectedImage, gotImage)
+			}
+		})
 	}
 }
 

--- a/envvar_test.go
+++ b/envvar_test.go
@@ -97,7 +97,7 @@ func TestProjectEnvVarSetErrorInOneOfTheApps(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps/proj1-stage/env",
 		code:    http.StatusInternalServerError,
 		payload: []byte("something went wrong"),
@@ -105,7 +105,7 @@ func TestProjectEnvVarSetErrorInOneOfTheApps(t *testing.T) {
 	appNames := []string{"proj1-dev", "proj1-prod"}
 	for _, appName := range appNames {
 		server.prepareResponse(preparedResponse{
-			method:  "POST",
+			method:  http.MethodPost,
 			path:    "/apps/" + appName + "/env",
 			code:    http.StatusOK,
 			payload: []byte("{}"),
@@ -199,7 +199,7 @@ func TestProjectEnvVarGetErrorInOneOfTheApps(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps/proj1-stage/env",
 		code:    http.StatusInternalServerError,
 		payload: []byte("something went wrong"),
@@ -225,7 +225,7 @@ func TestProjectEnvVarGetErrorInOneOfTheApps(t *testing.T) {
 		}
 		payload, _ := json.Marshal(rawPayload)
 		server.prepareResponse(preparedResponse{
-			method:  "GET",
+			method:  http.MethodGet,
 			path:    "/apps/" + appName + "/env",
 			code:    http.StatusOK,
 			payload: payload,
@@ -320,7 +320,7 @@ func TestProjectEnvVarUnsetError(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:   "DELETE",
+		method:   http.MethodDelete,
 		path:     "/apps/proj1-stage/env",
 		code:     http.StatusInternalServerError,
 		payload:  []byte("something went wrong"),
@@ -329,7 +329,7 @@ func TestProjectEnvVarUnsetError(t *testing.T) {
 	appNames := []string{"proj1-dev", "proj1-prod"}
 	for _, appName := range appNames {
 		server.prepareResponse(preparedResponse{
-			method:   "DELETE",
+			method:   http.MethodDelete,
 			path:     "/apps/" + appName + "/env",
 			code:     http.StatusOK,
 			payload:  []byte("{}"),

--- a/envvari_test.go
+++ b/envvari_test.go
@@ -200,6 +200,7 @@ func TestProjectEnvVarGet(t *testing.T) {
 	}
 	expectedOutput := `variables in "dev":
 
+ TRANOR_ENV_NAME=dev
  TSURU_APPDIR=*** (private variable)
  TSURU_APPNAME=*** (private variable)
  TSURU_APP_TOKEN=*** (private variable)
@@ -207,6 +208,7 @@ func TestProjectEnvVarGet(t *testing.T) {
 
 variables in "stage":
 
+ TRANOR_ENV_NAME=stage
  TSURU_APPDIR=*** (private variable)
  TSURU_APPNAME=*** (private variable)
  TSURU_APP_TOKEN=*** (private variable)
@@ -214,6 +216,7 @@ variables in "stage":
 
 variables in "prod":
 
+ TRANOR_ENV_NAME=prod
  TSURU_APPDIR=*** (private variable)
  TSURU_APPNAME=*** (private variable)
  TSURU_APP_TOKEN=*** (private variable)
@@ -256,6 +259,7 @@ func TestProjectEnvVarGetDefaultEnvs(t *testing.T) {
 	}
 	expectedOutput := `variables in "dev":
 
+ TRANOR_ENV_NAME=dev
  TSURU_APPDIR=*** (private variable)
  TSURU_APPNAME=*** (private variable)
  TSURU_APP_TOKEN=*** (private variable)
@@ -263,6 +267,7 @@ func TestProjectEnvVarGetDefaultEnvs(t *testing.T) {
 
 variables in "qa":
 
+ TRANOR_ENV_NAME=qa
  TSURU_APPDIR=*** (private variable)
  TSURU_APPNAME=*** (private variable)
  TSURU_APP_TOKEN=*** (private variable)
@@ -270,6 +275,7 @@ variables in "qa":
 
 variables in "stage":
 
+ TRANOR_ENV_NAME=stage
  TSURU_APPDIR=*** (private variable)
  TSURU_APPNAME=*** (private variable)
  TSURU_APP_TOKEN=*** (private variable)
@@ -277,6 +283,7 @@ variables in "stage":
 
 variables in "prod":
 
+ TRANOR_ENV_NAME=prod
  TSURU_APPDIR=*** (private variable)
  TSURU_APPNAME=*** (private variable)
  TSURU_APP_TOKEN=*** (private variable)
@@ -324,6 +331,7 @@ func TestProjectEnvVarGetAppNotFound(t *testing.T) {
 	}
 	expectedOutput := `variables in "dev":
 
+ TRANOR_ENV_NAME=dev
  TSURU_APPDIR=*** (private variable)
  TSURU_APPNAME=*** (private variable)
  TSURU_APP_TOKEN=*** (private variable)
@@ -331,6 +339,7 @@ func TestProjectEnvVarGetAppNotFound(t *testing.T) {
 
 variables in "prod":
 
+ TRANOR_ENV_NAME=prod
  TSURU_APPDIR=*** (private variable)
  TSURU_APPNAME=*** (private variable)
  TSURU_APP_TOKEN=*** (private variable)

--- a/envvari_test.go
+++ b/envvari_test.go
@@ -378,6 +378,9 @@ func TestProjectEnvVarUnset(t *testing.T) {
 		Team:        "myteam",
 		Platform:    "python",
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	var c projectEnvVarUnset
 	err = c.Flags().Parse(true, []string{
 		"-n", "myproj",
@@ -422,6 +425,9 @@ func TestProjectEnvVarUnsetDefaultEnvs(t *testing.T) {
 		Team:        "myteam",
 		Platform:    "python",
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = c.Flags().Parse(true, []string{
 		"-n", "myproj",
 		"--no-restart",

--- a/fake_tsuru_server_test.go
+++ b/fake_tsuru_server_test.go
@@ -40,9 +40,9 @@ func (s *fakeTsuruServer) buildRouter() {
 	r := s.router.PathPrefix("/1.0").Subrouter()
 	r.HandleFunc("/apps", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
-		case "POST":
+		case http.MethodPost:
 			s.createApp(w, r)
-		case "GET":
+		case http.MethodGet:
 			s.listApps(w, r)
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -50,11 +50,11 @@ func (s *fakeTsuruServer) buildRouter() {
 	})
 	r.HandleFunc("/apps/{appname}", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
-		case "PUT":
+		case http.MethodPut:
 			s.updateApp(w, r)
-		case "GET":
+		case http.MethodGet:
 			s.getApp(w, r)
-		case "DELETE":
+		case http.MethodDelete:
 			s.deleteApp(w, r)
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -62,11 +62,11 @@ func (s *fakeTsuruServer) buildRouter() {
 	})
 	r.HandleFunc("/apps/{appname}/env", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
-		case "POST":
+		case http.MethodPost:
 			s.setEnvs(w, r)
-		case "GET":
+		case http.MethodGet:
 			s.getEnvs(w, r)
-		case "DELETE":
+		case http.MethodDelete:
 			s.unsetEnvs(w, r)
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ func buildManager(name string) *cmd.Manager {
 	mngr.Register(&projectEnvVarGet{})
 	mngr.Register(&projectEnvVarSet{})
 	mngr.Register(&projectEnvVarUnset{})
+	mngr.Register(&projectDeploy{})
+	mngr.Register(&projectDeployList{})
 	return mngr
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -212,6 +212,28 @@ func TestProjectEnvVarUnsetIsRegistered(t *testing.T) {
 	}
 }
 
+func TestProjectDeployIsRegistered(t *testing.T) {
+	manager := buildManager("tranor")
+	gotCommand, ok := manager.Commands["project-deploy"]
+	if !ok {
+		t.Error("command deploy not found")
+	}
+	if _, ok := gotCommand.(*projectDeploy); !ok {
+		t.Errorf("command %#v is not of type projectDeploy{}", gotCommand)
+	}
+}
+
+func TestProjectDeployListIsRegistered(t *testing.T) {
+	manager := buildManager("tranor")
+	gotCommand, ok := manager.Commands["project-deploy-list"]
+	if !ok {
+		t.Error("command deploy-list not found")
+	}
+	if _, ok := gotCommand.(*projectDeployList); !ok {
+		t.Errorf("command %#v is not of type projectDeployList{}", gotCommand)
+	}
+}
+
 func TestBuiltinTargetSetIsOverwritten(t *testing.T) {
 	manager := buildManager("tranor")
 	gotCommand, ok := manager.Commands["target-set"]

--- a/project.go
+++ b/project.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/tsuru/gnuflag"
 	"github.com/tsuru/tsuru-client/tsuru/client"
+	"github.com/tsuru/tsuru/api"
 	"github.com/tsuru/tsuru/cmd"
 	tsuruerrors "github.com/tsuru/tsuru/errors"
 )
@@ -514,6 +515,14 @@ func createApps(envs []Environment, client *cmd.Client, projectName string, opts
 		}
 		a["name"] = opts.Name
 		a["dnsSuffix"] = env.DNSSuffix
+		setEnvVars(client, opts.Name, &api.Envs{
+			Envs: []struct {
+				Name  string
+				Value string
+			}{
+				{Name: "TRANOR_ENV_NAME", Value: env.Name},
+			},
+		})
 		createdApps = append(createdApps, a)
 		apps = append(apps, app{Name: opts.Name})
 	}

--- a/project.go
+++ b/project.go
@@ -538,7 +538,7 @@ func setCNames(apps []map[string]string, client *cmd.Client, projectName string)
 		cname := fmt.Sprintf("%s.%s", projectName, app["dnsSuffix"])
 		v := make(url.Values)
 		v.Set("cname", cname)
-		req, err := http.NewRequest("POST", reqURL, strings.NewReader(v.Encode()))
+		req, err := http.NewRequest(http.MethodPost, reqURL, strings.NewReader(v.Encode()))
 		if err != nil {
 			return err
 		}

--- a/project.go
+++ b/project.go
@@ -561,9 +561,6 @@ func projectApps(client *cmd.Client, name string) ([]app, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(apps) == 0 {
-		return nil, errors.New("project not found")
-	}
 	var projectApps []app
 	for _, env := range config.Environments {
 		for _, app := range apps {
@@ -584,6 +581,9 @@ func projectApps(client *cmd.Client, name string) ([]app, error) {
 				projectApps = append(projectApps, app)
 			}
 		}
+	}
+	if len(projectApps) == 0 {
+		return nil, errors.New("project not found")
 	}
 	return projectApps, nil
 }

--- a/project_test.go
+++ b/project_test.go
@@ -282,9 +282,10 @@ func TestProjectCreateFailToSetCNames(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected <nil> error")
 	}
-	expectedMethods := []string{"POST", "POST", "POST", "POST", "DELETE", "DELETE"}
+	expectedMethods := []string{"POST", "POST", "POST", "POST", "POST", "POST", "DELETE", "DELETE"}
 	expectedPaths := []string{
-		"/1.0/apps", "/1.0/apps",
+		"/1.0/apps", "/1.0/apps/superproj-dev/env",
+		"/1.0/apps", "/1.0/apps/superproj-prod/env",
 		"/1.0/apps/superproj-dev/cname",
 		"/1.0/apps/superproj-prod/cname",
 		"/1.0/apps/superproj-dev",

--- a/project_test.go
+++ b/project_test.go
@@ -95,7 +95,7 @@ func TestProjectCreateNoRepo(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps",
 		code:    http.StatusCreated,
 		payload: []byte(`{}`),
@@ -103,7 +103,7 @@ func TestProjectCreateNoRepo(t *testing.T) {
 	appNames := []string{"superproj-dev", "superproj-prod"}
 	for _, appName := range appNames {
 		server.prepareResponse(preparedResponse{
-			method:  "POST",
+			method:  http.MethodPost,
 			path:    "/apps/" + appName + "/cname",
 			code:    http.StatusOK,
 			payload: []byte(`{}`),
@@ -238,24 +238,24 @@ func TestProjectCreateFailToSetCNames(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps",
 		code:    http.StatusCreated,
 		payload: []byte(`{"repository_url":"git@git.example.com:superproj-dev.git"}`),
 	})
 	server.prepareResponse(preparedResponse{
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps/superproj-dev/cname",
 		code:    http.StatusOK,
 		payload: []byte(`{}`),
 	})
 	server.prepareResponse(preparedResponse{
-		method: "DELETE",
+		method: http.MethodDelete,
 		path:   "/apps/superproj-prod",
 		code:   http.StatusOK,
 	})
 	server.prepareResponse(preparedResponse{
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps/superproj-prod/cname",
 		code:    http.StatusInternalServerError,
 		payload: []byte(`{}`),
@@ -282,7 +282,7 @@ func TestProjectCreateFailToSetCNames(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected <nil> error")
 	}
-	expectedMethods := []string{"POST", "POST", "POST", "POST", "POST", "POST", "DELETE", "DELETE"}
+	expectedMethods := []string{http.MethodPost, "POST", "POST", "POST", "POST", "POST", http.MethodDelete, "DELETE"}
 	expectedPaths := []string{
 		"/1.0/apps", "/1.0/apps/superproj-dev/env",
 		"/1.0/apps", "/1.0/apps/superproj-prod/env",
@@ -330,7 +330,7 @@ func TestProjectUpdateNotFound(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method: "GET",
+		method: http.MethodGet,
 		path:   "/apps?name=" + url.QueryEscape("^proj3"),
 		code:   http.StatusNoContent,
 	})
@@ -368,7 +368,7 @@ func TestProjectUpdateFailToCreateNewApps(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?name=" + url.QueryEscape("^proj3"),
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
@@ -379,14 +379,14 @@ func TestProjectUpdateFailToCreateNewApps(t *testing.T) {
 	}
 	for appName, payload := range appRespMap {
 		server.prepareResponse(preparedResponse{
-			method:  "GET",
+			method:  http.MethodGet,
 			path:    "/apps/" + appName,
 			code:    http.StatusOK,
 			payload: payload,
 		})
 	}
 	server.prepareResponse(preparedResponse{
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps",
 		code:    http.StatusInternalServerError,
 		payload: []byte(`{}`),
@@ -421,7 +421,7 @@ func TestProjectUpdateFailToSetCNames(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?name=" + url.QueryEscape("^proj3"),
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
@@ -432,25 +432,25 @@ func TestProjectUpdateFailToSetCNames(t *testing.T) {
 	}
 	for appName, payload := range appRespMap {
 		server.prepareResponse(preparedResponse{
-			method:  "GET",
+			method:  http.MethodGet,
 			path:    "/apps/" + appName,
 			code:    http.StatusOK,
 			payload: payload,
 		})
 	}
 	server.prepareResponse(preparedResponse{
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps",
 		code:    http.StatusCreated,
 		payload: []byte(`{}`),
 	})
 	server.prepareResponse(preparedResponse{
-		method: "POST",
+		method: http.MethodPost,
 		path:   "/apps/proj3-qa/cname",
 		code:   http.StatusOK,
 	})
 	server.prepareResponse(preparedResponse{
-		method: "POST",
+		method: http.MethodPost,
 		path:   "/apps/proj3-stage/cname",
 		code:   http.StatusInternalServerError,
 	})
@@ -484,7 +484,7 @@ func TestProjectUpdateFailToUpdate(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?name=" + url.QueryEscape("^proj3"),
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
@@ -495,35 +495,35 @@ func TestProjectUpdateFailToUpdate(t *testing.T) {
 	}
 	for appName, payload := range appRespMap {
 		server.prepareResponse(preparedResponse{
-			method:  "GET",
+			method:  http.MethodGet,
 			path:    "/apps/" + appName,
 			code:    http.StatusOK,
 			payload: payload,
 		})
 	}
 	server.prepareResponse(preparedResponse{
-		method: "DELETE",
+		method: http.MethodDelete,
 		path:   "/apps/proj3-dev",
 		code:   http.StatusOK,
 	})
 	server.prepareResponse(preparedResponse{
-		method: "PUT",
+		method: http.MethodPut,
 		path:   "/apps/proj3-prod",
 		code:   http.StatusInternalServerError,
 	})
 	server.prepareResponse(preparedResponse{
-		method:  "POST",
+		method:  http.MethodPost,
 		path:    "/apps",
 		code:    http.StatusCreated,
 		payload: []byte(`{}`),
 	})
 	server.prepareResponse(preparedResponse{
-		method: "POST",
+		method: http.MethodPost,
 		path:   "/apps/proj3-qa/cname",
 		code:   http.StatusOK,
 	})
 	server.prepareResponse(preparedResponse{
-		method: "POST",
+		method: http.MethodPost,
 		path:   "/apps/proj3-stage/cname",
 		code:   http.StatusOK,
 	})
@@ -557,7 +557,7 @@ func TestProjectUpdateInvalidNewEnv(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?name=" + url.QueryEscape("^proj3"),
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
@@ -568,7 +568,7 @@ func TestProjectUpdateInvalidNewEnv(t *testing.T) {
 	}
 	for appName, payload := range appRespMap {
 		server.prepareResponse(preparedResponse{
-			method:  "GET",
+			method:  http.MethodGet,
 			path:    "/apps/" + appName,
 			code:    http.StatusOK,
 			payload: payload,
@@ -601,7 +601,7 @@ func TestProjectUpdateDuplicateEnv(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?name=" + url.QueryEscape("^proj3"),
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
@@ -612,7 +612,7 @@ func TestProjectUpdateDuplicateEnv(t *testing.T) {
 	}
 	for appName, payload := range appRespMap {
 		server.prepareResponse(preparedResponse{
-			method:  "GET",
+			method:  http.MethodGet,
 			path:    "/apps/" + appName,
 			code:    http.StatusOK,
 			payload: payload,
@@ -649,7 +649,7 @@ func TestProjectUpdateInvalidRemoveEnvs(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?name=" + url.QueryEscape("^proj3"),
 		code:    http.StatusOK,
 		payload: []byte(listOfApps),
@@ -660,7 +660,7 @@ func TestProjectUpdateInvalidRemoveEnvs(t *testing.T) {
 	}
 	for appName, payload := range appRespMap {
 		server.prepareResponse(preparedResponse{
-			method:  "GET",
+			method:  http.MethodGet,
 			path:    "/apps/" + appName,
 			code:    http.StatusOK,
 			payload: payload,
@@ -780,7 +780,7 @@ func TestProjectInfoErrorToListApps(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps?name=proj1",
 		code:    http.StatusInternalServerError,
 		payload: []byte("something went wrong"),
@@ -877,7 +877,7 @@ func TestProjectListErrorToListApps(t *testing.T) {
 	server := newFakeServer(t)
 	defer server.stop()
 	server.prepareResponse(preparedResponse{
-		method:  "GET",
+		method:  http.MethodGet,
 		path:    "/apps",
 		code:    http.StatusInternalServerError,
 		payload: []byte("something went wrong"),

--- a/project_test.go
+++ b/project_test.go
@@ -922,7 +922,8 @@ func setupFakeConfig(target, token string) (func(), error) {
 	os.Unsetenv("TSURU_HOST")
 	os.Setenv("TSURU_TOKEN", token)
 	config := Config{
-		Target: target,
+		Target:   target,
+		Registry: "docker-registry.example.com",
 		Environments: []Environment{
 			{
 				Name:      "dev",

--- a/projecti_test.go
+++ b/projecti_test.go
@@ -762,6 +762,9 @@ func TestProjectList(t *testing.T) {
 			Team:        "myteam",
 			Platform:    "python",
 		})
+		if innerErr != nil {
+			t.Fatal(innerErr)
+		}
 		innerErr = setCNames(appMaps, client, projName)
 		if innerErr != nil {
 			t.Fatal(innerErr)
@@ -776,6 +779,9 @@ func TestProjectList(t *testing.T) {
 		Team:        "myteam",
 		Platform:    "python",
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = setCNames(appMaps, client, "myproj3")
 	if err != nil {
 		t.Fatal(err)

--- a/target_test.go
+++ b/target_test.go
@@ -33,7 +33,7 @@ func TestTargetSetRun(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/config.json":
-			w.Write([]byte(`{"target":"mytarget","envs":[]}`))
+			w.Write([]byte(`{"target":"mytarget","registry":"localhost:3030","envs":[]}`))
 		default:
 			http.Error(w, "not found", http.StatusNotFound)
 		}
@@ -58,7 +58,7 @@ func TestTargetSetRun(t *testing.T) {
 	expectedMsg := "Target successfully defined!\n"
 	expectedTarget := "mytarget"
 	expectedTargets := "tranor\tmytarget\n"
-	expectedConfig := `{"target":"mytarget","envs":[]}` + "\n"
+	expectedConfig := `{"target":"mytarget","registry":"localhost:3030","envs":[]}` + "\n"
 	if stdout.String() != expectedMsg {
 		t.Errorf("wrong stdout msg.\nWant %q\nGot  %q", expectedMsg, stdout.String())
 	}
@@ -109,7 +109,7 @@ func TestTargetSetRunFailure(t *testing.T) {
 }
 
 func TestDownloadConfiguration(t *testing.T) {
-	config := `{"target":"http://mytarget.example.com","envs":[]}`
+	config := `{"target":"http://mytarget.example.com","registry":"localhost:5000","envs":[]}`
 	var req http.Request
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req = *r

--- a/target_test.go
+++ b/target_test.go
@@ -134,8 +134,8 @@ func TestDownloadConfiguration(t *testing.T) {
 	if string(content) != config {
 		t.Errorf("wrong config written. Want %q. Got %q", config, string(content))
 	}
-	if req.Method != "GET" {
-		t.Errorf("wrong method in request. Want %q. Got %q", "GET", req.Method)
+	if req.Method != http.MethodGet {
+		t.Errorf("wrong method in request. Want %q. Got %q", http.MethodGet, req.Method)
 	}
 	if req.URL.Path != "/config.json" {
 		t.Errorf("wrong path in request. Want %q. Got %q", "/config.json", req.URL.Path)

--- a/testdata/.tranor/config.json
+++ b/testdata/.tranor/config.json
@@ -1,5 +1,6 @@
 {
 	"target": "http://tsuru-api.example.com",
+	"registry": "localhost:5000",
 	"envs": [
 		{
 			"name": "dev",

--- a/usage.md
+++ b/usage.md
@@ -47,7 +47,7 @@ Use tranor help <topicname> to get more information about a topic.
 The command ``tranor target-set`` will define your remote tranor server:
 
 ```
-% tranor target-set https://gist.githubusercontent.com/fsouza/ac50e24d18bd7c24588164481fa3686b/raw/08d693a2da421dcf5a0ac0e02ba45c050d44fc57
+% tranor target-set https://gist.githubusercontent.com/fsouza/ac50e24d18bd7c24588164481fa3686b/raw/482b60f8ecff0cf77bcc2db8903dff5492910447
 Target successfully defined!
 ```
 
@@ -475,4 +475,235 @@ variables in "prod":
  DATABASE_NAME=mydb
  TSURU_APPNAME=*** (private variable)
  TSURU_APPDIR=*** (private variable)
+```
+
+## project-deploy
+
+The command ``tranor project-deploy`` is used to deploy a project. There are
+three ways of deploy a project using ``tranor project-deploy``:
+
+1. Uploading the contents
+1. Using a Docker image
+1. Promoting a version that is running in another environment
+
+For the first two options, the user can only deploy to the project "initial"
+environment. Environments follow a definition order, usually dev > qa > stage >
+prod. This mean that the default initial environment is dev, but if an
+application has only qa and prod, the initial environment is qa.
+
+If users want to deploy to another environment, they should use the
+``-p/--promote`` flag.
+
+Deploying to the initial environment (dev):
+
+```
+% tranor project-deploy -n myproj -e dev .
+Uploading files (0.01MB)... 100.00% Processing..... ok
+/home/application/current /
+Collecting Flask==0.10.1 (from -r /home/application/current/requirements.txt (line 1))
+  Downloading Flask-0.10.1.tar.gz (544kB)
+Collecting Werkzeug>=0.7 (from Flask==0.10.1->-r /home/application/current/requirements.txt (line 1))
+  Downloading Werkzeug-0.11.11-py2.py3-none-any.whl (306kB)
+Collecting Jinja2>=2.4 (from Flask==0.10.1->-r /home/application/current/requirements.txt (line 1))
+  Downloading Jinja2-2.8-py2.py3-none-any.whl (263kB)
+Collecting itsdangerous>=0.21 (from Flask==0.10.1->-r /home/application/current/requirements.txt (line 1))
+  Downloading itsdangerous-0.24.tar.gz (46kB)
+Collecting MarkupSafe (from Jinja2>=2.4->Flask==0.10.1->-r /home/application/current/requirements.txt (line 1))
+  Downloading MarkupSafe-0.23.tar.gz
+Installing collected packages: Werkzeug, MarkupSafe, Jinja2, itsdangerous, Flask
+  Running setup.py install for MarkupSafe: started
+    Running setup.py install for MarkupSafe: finished with status 'done'
+  Running setup.py install for itsdangerous: started
+    Running setup.py install for itsdangerous: finished with status 'done'
+  Running setup.py install for Flask: started
+    Running setup.py install for Flask: finished with status 'done'
+Successfully installed Flask-0.10.1 Jinja2-2.8 MarkupSafe-0.23 Werkzeug-0.11.11 itsdangerous-0.24
+/
+
+---- Building application image ----
+ ---> Sending image to repository (5.05MB)
+ ---> Cleaning up
+
+---- Starting 1 new unit [web: 1] ----
+ ---> Started unit ce122a515e [web]
+
+---- Binding and checking 1 new unit ----
+ ---> Bound and checked unit ce122a515e [web]
+
+---- Adding routes to new units ----
+ ---> Added route to unit ce122a515e [web]
+
+---- Setting router healthcheck (Path: /) ----
+
+OK
+```
+
+Deploying a Docker image to the initial environment:
+
+```
+% tranor project-deploy -n myproj -e dev -i tsuru/tsuru-dashboard
+Deploying image... ok
+---- Pulling image to tsuru ----
+Pulling repository docker.io/tsuru/tsuru-dashboard
+error in docker node "https://192.168.99.100:2376": Error: image tsuru/tsuru-dashboard:latest not found
+% tranor project-deploy -n myproj -e dev -i tsuru/dashboard
+Deploying image... ok
+---- Pulling image to tsuru ----
+latest: Pulling from tsuru/dashboard
+Digest: sha256:a2d1f38ed30fafd1b6452847e3b63842817265d87b26dd108665c93c2e7f0d9f
+Status: Image is up to date for tsuru/dashboard:latest
+---- Getting process from image ----
+  ---> Process web found with command: gunicorn --access-logfile - -b 0.0.0.0:$PORT -w 2 abyss.wsgi -k gevent
+---- Pushing image to tsuru ----
+The push refers to a repository [192.168.99.100:5000/tsuru/app-myproj-dev]
+4cb50f5c84bc: Preparing
+af4d412b051e: Preparing
+5ed19e57c425: Preparing
+22518baa7d14: Preparing
+40a3f7f78596: Preparing
+0eac9fd0bf03: Preparing
+02ab82d82f1b: Preparing
+e4c62e08842a: Preparing
+4c57ca702cb9: Preparing
+f2b7c55206b1: Preparing
+ddd02798417c: Preparing
+fcbecd85db47: Preparing
+6cb2a13b80d9: Preparing
+5f70bf18a086: Preparing
+45befd8a8901: Preparing
+0eac9fd0bf03: Waiting
+02ab82d82f1b: Waiting
+e4c62e08842a: Waiting
+4c57ca702cb9: Waiting
+f2b7c55206b1: Waiting
+ddd02798417c: Waiting
+fcbecd85db47: Waiting
+6cb2a13b80d9: Waiting
+5f70bf18a086: Waiting
+45befd8a8901: Waiting
+4cb50f5c84bc: Mounted from tsuru/app-tsuru-dashboard
+22518baa7d14: Mounted from tsuru/app-tsuru-dashboard
+af4d412b051e: Mounted from tsuru/app-tsuru-dashboard
+40a3f7f78596: Mounted from tsuru/app-tsuru-dashboard
+e4c62e08842a: Mounted from tsuru/app-tsuru-dashboard
+02ab82d82f1b: Mounted from tsuru/app-tsuru-dashboard
+5ed19e57c425: Mounted from tsuru/app-tsuru-dashboard
+f2b7c55206b1: Layer already exists
+6cb2a13b80d9: Layer already exists
+0eac9fd0bf03: Mounted from tsuru/app-tsuru-dashboard
+ddd02798417c: Layer already exists
+45befd8a8901: Layer already exists
+fcbecd85db47: Layer already exists
+4c57ca702cb9: Mounted from tsuru/app-tsuru-dashboard
+5f70bf18a086: Layer already exists
+v3: digest: sha256:a2d1f38ed30fafd1b6452847e3b63842817265d87b26dd108665c93c2e7f0d9f size: 3462
+
+---- Starting 1 new unit [web: 1] ----
+ ---> Started unit 6ffcd7272d [web]
+
+---- Binding and checking 1 new unit ----
+ ---> Bound and checked unit 6ffcd7272d [web]
+
+---- Adding routes to new units ----
+ ---> Added route to unit 6ffcd7272d [web]
+
+---- Setting router healthcheck (Path: /) ----
+
+---- Removing routes from old units ----
+ ---> Removed route from unit ce122a515e [web]
+
+---- Removing 1 old unit ----
+ ---> Removed old unit ce122a515e [web]
+
+---- Unbinding 1 old unit ----
+ ---> Removed bind for old unit ce122a515e [web]
+
+OK
+```
+
+Promoting from the initial environment (dev) to another environment (prod):
+
+```
+% tranor project-deploy -n myproj -e prod -p dev
+Deploying image... ok
+---- Pulling image to tsuru ----
+v3: Pulling from tsuru/app-myproj-dev
+Digest: sha256:a2d1f38ed30fafd1b6452847e3b63842817265d87b26dd108665c93c2e7f0d9f
+Status: Downloaded newer image for localhost:5000/tsuru/app-myproj-dev:v3
+---- Getting process from image ----
+  ---> Process web found with command: gunicorn --access-logfile - -b 0.0.0.0:$PORT -w 2 abyss.wsgi -k gevent
+---- Pushing image to tsuru ----
+The push refers to a repository [192.168.99.100:5000/tsuru/app-myproj-prod]
+4cb50f5c84bc: Preparing
+af4d412b051e: Preparing
+5ed19e57c425: Preparing
+22518baa7d14: Preparing
+40a3f7f78596: Preparing
+0eac9fd0bf03: Preparing
+02ab82d82f1b: Preparing
+e4c62e08842a: Preparing
+4c57ca702cb9: Preparing
+f2b7c55206b1: Preparing
+ddd02798417c: Preparing
+fcbecd85db47: Preparing
+6cb2a13b80d9: Preparing
+5f70bf18a086: Preparing
+45befd8a8901: Preparing
+0eac9fd0bf03: Waiting
+02ab82d82f1b: Waiting
+e4c62e08842a: Waiting
+4c57ca702cb9: Waiting
+f2b7c55206b1: Waiting
+ddd02798417c: Waiting
+fcbecd85db47: Waiting
+6cb2a13b80d9: Waiting
+5f70bf18a086: Waiting
+45befd8a8901: Waiting
+5ed19e57c425: Mounted from tsuru/app-myproj-dev
+4cb50f5c84bc: Mounted from tsuru/app-myproj-dev
+af4d412b051e: Mounted from tsuru/app-myproj-dev
+22518baa7d14: Mounted from tsuru/app-myproj-dev
+0eac9fd0bf03: Mounted from tsuru/app-myproj-dev
+40a3f7f78596: Mounted from tsuru/app-myproj-dev
+02ab82d82f1b: Mounted from tsuru/app-myproj-dev
+fcbecd85db47: Layer already exists
+f2b7c55206b1: Layer already exists
+ddd02798417c: Layer already exists
+45befd8a8901: Layer already exists
+6cb2a13b80d9: Layer already exists
+4c57ca702cb9: Mounted from tsuru/app-myproj-dev
+5f70bf18a086: Layer already exists
+e4c62e08842a: Mounted from tsuru/app-myproj-dev
+v2: digest: sha256:a2d1f38ed30fafd1b6452847e3b63842817265d87b26dd108665c93c2e7f0d9f size: 3462
+
+---- Starting 1 new unit [web: 1] ----
+ ---> Started unit e09d7ea121 [web]
+
+---- Binding and checking 1 new unit ----
+ ---> Bound and checked unit e09d7ea121 [web]
+
+---- Adding routes to new units ----
+ ---> Added route to unit e09d7ea121 [web]
+
+---- Setting router healthcheck (Path: /) ----
+
+---- Removing routes from old units ----
+ ---> Removed route from unit 71b4c89262 [web]
+
+---- Removing 1 old unit ----
+ ---> Removed old unit 71b4c89262 [web]
+
+---- Unbinding 1 old unit ----
+ ---> Removed bind for old unit 71b4c89262 [web]
+
+OK
+```
+
+Trying to deploy directly to a non-initial environment (prod):
+
+```
+% tranor project-deploy -n myproj -e prod .
+Error: can only deploy directly to "dev", use -p/--promote to deploy to other environments
+% tranor project-deploy -n myproj -e prod -i tsuru/dashboard
+Error: can only deploy directly to "dev", use -p/--promote to deploy to other environments
 ```


### PR DESCRIPTION
**Attention:** I'm targeting the integration-tests branch because this PR depends on #5. After #5 is merged I'll rebase and change the target of this PR.

How to test this PR:
### Setup tranor
1. check it out locally
2. make sure you have latest version of tsuru-client (brew install tsuru/tsuru/tsuru, apt-get install tsuru-client or checkout and build)
3. run `tsuru install`
4. run `TSURU_TEST_HOST=http://192.168.99.100:8080 TSURU_TEST_TOKEN=$(tsuru token-show | awk '{print $3}') make prepare-test-server`
5. configure tranor: `tranor target-set https://gist.githubusercontent.com/fsouza/ac50e24d18bd7c24588164481fa3686b/raw/482b60f8ecff0cf77bcc2db8903dff5492910447`
6. create a project: `tranor project-create -n myproj -l python -t myteam`
### Deploy to dev
1. change association of docker node to dev pool: `tsuru-admin docker-node-update https://192.168.99.100:2376 'pool=dev\dev.example.com'`
2. deploy some code to dev ([simple-flask-example](https://github.com/andrewsmedina/simple-flask-example), for example) `tranor project-deploy -n myproj -e dev .`

```
% tranor project-deploy -n myproj -e dev .
Uploading files (0.01MB)... 100.00% Processing..... ok
/home/application/current /
Collecting Flask==0.10.1 (from -r /home/application/current/requirements.txt (line 1))
  Downloading Flask-0.10.1.tar.gz (544kB)
Collecting Werkzeug>=0.7 (from Flask==0.10.1->-r /home/application/current/requirements.txt (line 1))
  Downloading Werkzeug-0.11.11-py2.py3-none-any.whl (306kB)
Collecting Jinja2>=2.4 (from Flask==0.10.1->-r /home/application/current/requirements.txt (line 1))
  Downloading Jinja2-2.8-py2.py3-none-any.whl (263kB)
Collecting itsdangerous>=0.21 (from Flask==0.10.1->-r /home/application/current/requirements.txt (line 1))
  Downloading itsdangerous-0.24.tar.gz (46kB)
Collecting MarkupSafe (from Jinja2>=2.4->Flask==0.10.1->-r /home/application/current/requirements.txt (line 1))
  Downloading MarkupSafe-0.23.tar.gz
Installing collected packages: Werkzeug, MarkupSafe, Jinja2, itsdangerous, Flask
  Running setup.py install for MarkupSafe: started
    Running setup.py install for MarkupSafe: finished with status 'done'
  Running setup.py install for itsdangerous: started
    Running setup.py install for itsdangerous: finished with status 'done'
  Running setup.py install for Flask: started
    Running setup.py install for Flask: finished with status 'done'
Successfully installed Flask-0.10.1 Jinja2-2.8 MarkupSafe-0.23 Werkzeug-0.11.11 itsdangerous-0.24
/

---- Building application image ----
 ---> Sending image to repository (5.05MB)
 ---> Cleaning up

---- Starting 1 new unit [web: 1] ----
 ---> Started unit ce122a515e [web]

---- Binding and checking 1 new unit ----
 ---> Bound and checked unit ce122a515e [web]

---- Adding routes to new units ----
 ---> Added route to unit ce122a515e [web]

---- Setting router healthcheck (Path: /) ----

OK
```
### Promote to prod
1. change association of docker node to prod pool (I know it sucks, but we only have one node and a node cannot belong to multiple pools): `tsuru-admin docker-node-update https://192.168.99.100:2376 'pool=prod\example.com'`
2. promote from dev to prod `tranor project-deploy -n myproj -e prod -p dev`

```
% tranor project-deploy -n myproj -e prod -p dev
Deploying image... ok
---- Pulling image to tsuru ----
v2: Pulling from tsuru/app-myproj-dev
Digest: sha256:6b75330ea30924e31670da1f42f9aabf857fd9fc116d6c44fef4e6e7143ccb8e
Status: Downloaded newer image for localhost:5000/tsuru/app-myproj-dev:v2
---- Getting process from image ----
  ---> Process web found with command: python app.py
---- Pushing image to tsuru ----
The push refers to a repository [192.168.99.100:5000/tsuru/app-myproj-prod]
14d2416c85ce: Preparing
5e78ab837922: Preparing
422dbb1fdd60: Preparing
ff00b786a1f6: Preparing
a7ff9f535719: Preparing
f2b7c55206b1: Preparing
ddd02798417c: Preparing
fcbecd85db47: Preparing
6cb2a13b80d9: Preparing
5f70bf18a086: Preparing
45befd8a8901: Preparing
f2b7c55206b1: Waiting
ddd02798417c: Waiting
fcbecd85db47: Waiting
6cb2a13b80d9: Waiting
5f70bf18a086: Waiting
45befd8a8901: Waiting
ff00b786a1f6: Mounted from tsuru/app-myproj-dev
5e78ab837922: Mounted from tsuru/app-myproj-dev
14d2416c85ce: Mounted from tsuru/app-myproj-dev
a7ff9f535719: Mounted from tsuru/app-myproj-dev
422dbb1fdd60: Mounted from tsuru/app-myproj-dev
ddd02798417c: Mounted from tsuru/app-myproj-dev
f2b7c55206b1: Mounted from tsuru/app-myproj-dev
fcbecd85db47: Mounted from tsuru/app-myproj-dev
45befd8a8901: Mounted from tsuru/app-myproj-dev
6cb2a13b80d9: Mounted from tsuru/app-myproj-dev
5f70bf18a086: Mounted from tsuru/app-myproj-dev
v1: digest: sha256:6b75330ea30924e31670da1f42f9aabf857fd9fc116d6c44fef4e6e7143ccb8e size: 2621

---- Starting 1 new unit [web: 1] ----
 ---> Started unit 71b4c89262 [web]

---- Binding and checking 1 new unit ----
 ---> Bound and checked unit 71b4c89262 [web]

---- Adding routes to new units ----
 ---> Added route to unit 71b4c89262 [web]

---- Setting router healthcheck (Path: /) ----

OK
```
### Deploy directly to prod
1. try to deploy directly to prod `tranor project-deploy -n myproj -e prod .`

```
% tranor project-deploy -n myproj -e prod .
Error: can only deploy directly to "dev", use -p/--promote to deploy to other environments
```

I also updated README and added some documentation to usage.md.
