### PR TITLE
project: support multiple cnames on the app

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -276,7 +276,7 @@ func TestListApps(t *testing.T) {
 	}
 	expectedApps := []app{
 		{Name: "tsuru-dashboard", CName: []string{}},
-		{Name: "proj2-dev", CName: []string{"proj2.dev.example.com"}},
+		{Name: "proj2-dev", CName: []string{"proj2-dev.dev.example.com", "proj2.dev.example.com"}},
 		{Name: "proj2-qa", CName: []string{"proj2.qa.example.com"}},
 		{Name: "proj2-stage", CName: []string{"proj2.stage.example.com"}},
 		{Name: "proj2-prod", CName: []string{"proj2.example.com"}},

--- a/projecti_test.go
+++ b/projecti_test.go
@@ -212,7 +212,15 @@ func TestProjectUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = setCName(appMaps[0]["name"], "some-cname.example.com", client)
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = setCNames(appMaps, client, "myproj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = setCName(appMaps[0]["name"], "another-cname.example.com", client)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -779,6 +787,10 @@ func TestProjectList(t *testing.T) {
 		Team:        "myteam",
 		Platform:    "python",
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = setCName(appMaps[0]["name"], "some-cname.example.com", client)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stub_test.go
+++ b/stub_test.go
@@ -19,6 +19,7 @@ const listOfApps = `[
   {
     "name": "proj2-dev",
     "cname": [
+      "proj2-dev.dev.example.com",
       "proj2.dev.example.com"
     ],
     "ip": "proj2-dev.192.168.50.4.nip.io",


### PR DESCRIPTION
Instead of requiring a single cname, we now look for multiple cnames,
and if we can find the cname that matches the environment, that's ok.
This makes migration to tranor easier.